### PR TITLE
fix typo in normalize_mac, and undefined mac variable

### DIFF
--- a/lib/device.rb
+++ b/lib/device.rb
@@ -17,7 +17,9 @@ class Device
     end
 
     def create!(params)
-      DB.db.set(device_config_db_key(noramlize_mac(params[:mac])), params.to_json)
+      mac = params[:mac]
+      key = device_config_db_key(normalize_mac(mac))
+      DB.db.set(key, params.to_json)
       new(mac)
     end
 


### PR DESCRIPTION
I am just trying this out with:

```
curl -X GET http://localhost:5000/discover
curl -X POST -d '<OUTPUT OF DISCOVER>' http://localhost:5000/device
```

First I got an undefined method `noramlize_mac`, and then an undefined variable `mac`. I still have problems, but this fixes those two op to start.